### PR TITLE
Fix issue allowing others to use your terminal instance.

### DIFF
--- a/terminal/terminal.py
+++ b/terminal/terminal.py
@@ -176,7 +176,7 @@ class Terminal:
                 check_folder()
                 check_file()
 
-            if message.content.startswith(self.prefix) or message.content.startswith('debugprefixcmd') and self.bot.user.id == message.author.id:
+            if (message.content.startswith(self.prefix) or message.content.startswith('debugprefixcmd')) and self.bot.user.id == message.author.id:
                 command = message.content.split(self.prefix)[1]
                 # check if the message starts with the command prefix
 


### PR DESCRIPTION
When a terminal session is running, anyone could use your prefix and execute any command they wanted on your system (yikes!). This should fix it.